### PR TITLE
Fixing parity command.

### DIFF
--- a/parity-docker/start-parity.sh
+++ b/parity-docker/start-parity.sh
@@ -2,4 +2,4 @@
 
 mkdir -p /root/.local
 aws s3 sync --delete --region $region s3://$bucket/$s3key/.local/ /root/.local/
-/usr/bin/parity $*
+parity $*

--- a/updater-docker/start-parity.sh
+++ b/updater-docker/start-parity.sh
@@ -7,7 +7,7 @@ then
 	echo "aws s3 sync command failed; exiting."
 	exit 1
 fi
-/bin/parity $* &
+parity $* &
 sleep 1800
 pid=`ps -ef |grep parity/parity|grep -v grep|awk '{print $2}'`
 kill $pid


### PR DESCRIPTION
Hi there, thanks for this convenient template. One issue I found while using it was that the parity command is in /bin/parity, not in /usr/bin/parity. It's also in the $PATH anyways, so I just replaced it with plain "parity".